### PR TITLE
Change to use Codecov for coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ We’re currently using the following stack:
 - OS X (as this is for Apple platforms).
 - Travis-CI for running the CI jobs.
   - Other CI provides might work.
-- Slather for handling code coverage reporting.
-  - We’re currently sending ours to Coveralls but you should be able to use any Slather supports.
+- Codecov for code coverage reporting and visualization.
 
 ## Installing
 There are primarily two routes on how to add the scripts to your repository. Either as a git submodule (only appropriate for apps) or using git subtree merging.
@@ -48,9 +47,9 @@ $ cp ci/sample/Gemfile .
 $ bundle update
 ```
 
-Next you should configure [Travis-CI](#travis---ci) and [Slather](slather)
+Next you should configure Travis-CI.
 
-### Travis-CI
+### Travis-CI 🤖
 Also have a look at the [travis.yml](sample/travis.yml) file.
 
 The important environment variables you need to have set are:
@@ -66,9 +65,6 @@ The important environment variables you need to have set are:
 | `PODSPEC`                      	| The path to the project’s [CocoaPods](https://cocoapods.org/) podspec file.                	|
 | `EXPECTED_LICENSE_HEADER_FILE` 	| The path to a file containing the license header source files are expected to include.     	|
 | `LICENSED_SOURCE_FILES_GLOB`   	| A glob for finding all files which should be checked that they include the license header. 	|
-
-### Slather
-Also have a look at the [slather.yml](sample/slather.yml) file and have a look at [Slather’s own documentation](https://github.com/SlatherOrg/slather).
 
 ## Contributing :mailbox_with_mail:
 Contributions are welcomed, have a look at the [CONTRIBUTING.md](CONTRIBUTING.md) document for more information.

--- a/after_success.sh
+++ b/after_success.sh
@@ -23,7 +23,6 @@ PATH="$SCRIPT_DIR/bin:$PATH"
 
 set -euo pipefail
 
-travis_fold_open "Slather" "Publishing test coverage data…"
-bundle exec slather coverage \
-    --input-format profdata
-travis_fold_close "Slather"
+travis_fold_open "Codecov" "Publishing test coverage data…"
+bash <(curl -s https://codecov.io/bash)
+travis_fold_close "Codecov"

--- a/sample/slather.yml
+++ b/sample/slather.yml
@@ -1,7 +1,0 @@
-coverage_service: coveralls
-ci_service: travis_ci
-xcodeproj: SPTAwesome.xcodeproj
-scheme: SPTAwesome
-ignore:
-  - "../**/Developer/*"
-  - "SPTAwesomeTests/*"


### PR DESCRIPTION
This since the service makes it easier to look at your coverage and find what to fix. It also removes the dependency on Slather. Reducing the amount of configs and set-up steps by one.

@8W9aG 
