### PR TITLE
Fix missing quotes in travis_fold

### DIFF
--- a/bin/travis_fold
+++ b/bin/travis_fold
@@ -19,7 +19,7 @@
 # under the License.
 
 # Make sure we can execute this even if the `TRAVIS` variable isn’t set. It should default to false.
-: ${TRAVIS:=false}
+: "${TRAVIS:=false}"
 
 # Manipulate a Travis-CI group folding.
 #
@@ -28,9 +28,9 @@
 # @param $3 The header which should be shown on the first line of the group.
 travis_fold() {
 	if [ "$TRAVIS" == "true" ]; then
-		action="$1"
-		name="$2"
-		heading="$3"
+		local action="$1"
+		local name="$2"
+		local heading="$3"
 		echo -en "travis_fold:${action}:${name}\r\033[0K${heading}\n"
 	fi
 }


### PR DESCRIPTION
Found by running the linter on it. Also make the local variables be local.

That doesn’t yet happen in our master branch since we’re waiting for a fix of the linter to be merged.

@8W9aG 
