### PR TITLE
Silence direct ivar access warnings

### DIFF
--- a/spotify_os.xcconfig
+++ b/spotify_os.xcconfig
@@ -74,7 +74,7 @@ OTHER_LDFLAGS = -ObjC
 // Warnings:
 // Attribution: https://github.com/jonreid/XcodeWarnings
 
-WARNING_CFLAGS = -Weverything -Wno-error=deprecated -Wno-objc-missing-property-synthesis -Wno-gnu-conditional-omitted-operand -Wno-gnu -Wno-documentation-unknown-command -Wno-reserved-id-macro -Wno-auto-import -Wno-missing-variable-declarations -Wno-c++98-compat -Werror
+WARNING_CFLAGS = -Weverything -Wno-error=deprecated -Wno-objc-missing-property-synthesis -Wno-gnu-conditional-omitted-operand -Wno-gnu -Wno-documentation-unknown-command -Wno-reserved-id-macro -Wno-auto-import -Wno-missing-variable-declarations -Wno-c++98-compat -Werror -Wno-direct-ivar-access
 
 // Apple LLVM 7.0 - Warnings - All languages
 GCC_WARN_CHECK_SWITCH_STATEMENTS = YES


### PR DESCRIPTION
- These warnings are impossible to fulfill in some
  cases (example is low level audio functions)
