### PR TITLE
Add more platforms

### DIFF
--- a/spotify_os.xcconfig
+++ b/spotify_os.xcconfig
@@ -39,7 +39,7 @@ ENABLE_TESTABILITY_Debug = YES
 ENABLE_TESTABILITY_Release = NO
 ENABLE_TESTABILITY = $(ENABLE_TESTABILITY_$(CONFIGURATION))
 
-SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchsimulator appletvsimulator
+SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchsimulator appletvsimulator watchos
 
 CLANG_ENABLE_MODULES = YES
 CLANG_MODULES_AUTOLINK = NO

--- a/spotify_os.xcconfig
+++ b/spotify_os.xcconfig
@@ -39,7 +39,7 @@ ENABLE_TESTABILITY_Debug = YES
 ENABLE_TESTABILITY_Release = NO
 ENABLE_TESTABILITY = $(ENABLE_TESTABILITY_$(CONFIGURATION))
 
-SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchsimulator appletvsimulator watchos
+SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchsimulator appletvsimulator watchos appletvos
 
 CLANG_ENABLE_MODULES = YES
 CLANG_MODULES_AUTOLINK = NO


### PR DESCRIPTION
- Migrating to Xcode 7.3 shows us that despite putting the simulators as platforms in the supported platforms we still have to specify the original OS as well
