### PR TITLE
Drop armv7s from VALID_ARCHS

### DIFF
--- a/spotify_os.xcconfig
+++ b/spotify_os.xcconfig
@@ -19,7 +19,7 @@
 // A set of configurations used for Spotify Objective-C Open Source Projects
 
 // Project settings:
-VALID_ARCHS = i386 x86_64 armv7s armv7 arm64 armv7k
+VALID_ARCHS = i386 x86_64 armv7 arm64 armv7k
 IPHONEOS_DEPLOYMENT_TARGET = 7.0
 WATCHOS_DEPLOYMENT_TARGET = 2.0
 TVOS_DEPLOYMENT_TARGET = 9.0


### PR DESCRIPTION
We don’t support said slice.

@8W9aG @dflems 
