### PR TITLE
Disable linter rule SC2181 for license script

### DIFF
--- a/bin/validate_license_conformance.sh
+++ b/bin/validate_license_conformance.sh
@@ -47,6 +47,7 @@ for SOURCE_FILE in $LICENSED_SOURCE_FILES; do
             "$SOURCE_FILE") \
         &> /dev/null
 
+    # shellcheck disable=SC2181
     if [ "$?" == "0" ]; then
         echo -en "${FORMAT_SUCCESS}${SYMBOL_SUCCESS}${FORMAT_RESET}    \"${SOURCE_FILE}\""
     else


### PR DESCRIPTION
This disables the check which was by the linter in #17.

I opted to disable the rule for the statement instead of refactoring. Since putting the _large_ `diff` call in the if-statement would be terrible.

@Goos @8W9aG 